### PR TITLE
Fix to exclude unnamed components from PyForm file constructor

### DIFF
--- a/Source/Producer/PythonTools.Producer.AbstractForm.pas
+++ b/Source/Producer/PythonTools.Producer.AbstractForm.pas
@@ -122,6 +122,8 @@ var
 begin
   LProps := String.Empty;
   for LComp in AFormModel.ExportedComponents do begin
+    if LComp.ComponentName.IsEmpty() then
+      Continue;
     if not LProps.IsEmpty() then
       LProps := LProps
         + sLineBreak


### PR DESCRIPTION
When project contains forms with **unnamed components**, the "Form Producer" creates an incorrect line in the **__init__** constructor method (there is no name in the _"self.name = None"_ statement).

The fix allows excluding such components from the constructor so that the exported form does not contain syntactically invalid lines.